### PR TITLE
Mafinar/lotus/add utility props

### DIFF
--- a/lib/lotus/button.ex
+++ b/lib/lotus/button.ex
@@ -77,6 +77,6 @@ defmodule Lotus.Button do
   end
 
   defp button_class(assigns) do
-    button_kind_class(assigns) ++ get_classes(assigns)
+    button_kind_class(assigns) ++ base_classes(assigns)
   end
 end

--- a/lib/lotus/button.ex
+++ b/lib/lotus/button.ex
@@ -4,8 +4,6 @@ defmodule Lotus.Button do
   """
   use Lotus.Component
 
-  alias Lotus.Shared.Width
-
   @kinds ~w/default primary secondary danger text link/
   @sizes ~w/small large/
 
@@ -28,11 +26,6 @@ defmodule Lotus.Button do
   Size of this button
   """
   prop size, :string, values: @sizes
-
-  @doc """
-  Width of this button
-  """
-  prop width, :string, values: Width.width_specs()
 
   @doc """
   Width at small-screen
@@ -71,15 +64,25 @@ defmodule Lotus.Button do
     <button
       :on-click={@click}
       type="button"
-      class={[
-        "uk-button": @class == [],
-        "uk-button-#{@kind}": @kind,
-        "uk-button-#{@size}": @size
-      ] ++ Width.assigns_to_width_classes(assigns) ++ @class}
+      class={button_class(assigns)}
       {...@opts}
     >
       <#slot>{@label}</#slot>
     </button>
     """
+  end
+
+  defp button_kind_class(assigns) do
+    Surface.css_class(
+      "uk-button": assigns.class == [],
+      "uk-button-#{assigns.kind}": assigns.kind,
+      "uk-button-#{assigns.size}": assigns.size
+    )
+    |> List.wrap()
+  end
+
+  defp button_class(assigns) do
+    button_kind_class(assigns) ++
+      get_classes(assigns) ++ assigns.class
   end
 end

--- a/lib/lotus/button.ex
+++ b/lib/lotus/button.ex
@@ -56,12 +56,7 @@ defmodule Lotus.Button do
 
   def render(assigns) do
     ~F"""
-    <button
-      :on-click={@click}
-      type="button"
-      class={button_class(assigns)}
-      {...@opts}
-    >
+    <button :on-click={@click} type="button" class={button_class(assigns)} {...@opts}>
       <#slot>{@label}</#slot>
     </button>
     """

--- a/lib/lotus/button.ex
+++ b/lib/lotus/button.ex
@@ -8,11 +8,6 @@ defmodule Lotus.Button do
   @sizes ~w/small large/
 
   @doc """
-  Additional classes
-  """
-  prop class, :css_class, default: []
-
-  @doc """
   Label of the button, can be used in lieu of slot
   """
   prop label, :string
@@ -82,7 +77,6 @@ defmodule Lotus.Button do
   end
 
   defp button_class(assigns) do
-    button_kind_class(assigns) ++
-      get_classes(assigns) ++ assigns.class
+    button_kind_class(assigns) ++ get_classes(assigns)
   end
 end

--- a/lib/lotus/component.ex
+++ b/lib/lotus/component.ex
@@ -7,10 +7,12 @@ defmodule Lotus.Component do
       use Surface.Component
       use Lotus.Props.FallbackClass
       use Lotus.Props.Padding
+      use Lotus.Props.Text
       use Lotus.Props.Width
 
-      defp get_classes(assigns) do
-        padding_class(assigns) ++ width_class(assigns) ++ fallback_class(assigns)
+      defp base_classes(assigns) do
+        padding_class(assigns) ++
+          width_class(assigns) ++ text_class(assigns) ++ fallback_class(assigns)
       end
     end
   end

--- a/lib/lotus/component.ex
+++ b/lib/lotus/component.ex
@@ -8,11 +8,13 @@ defmodule Lotus.Component do
       use Lotus.Props.FallbackClass
       use Lotus.Props.Padding
       use Lotus.Props.Text
+      use Lotus.Props.Utility
       use Lotus.Props.Width
 
       defp base_classes(assigns) do
         padding_class(assigns) ++
-          width_class(assigns) ++ text_class(assigns) ++ fallback_class(assigns)
+          width_class(assigns) ++
+          text_class(assigns) ++ utility_class(assigns) ++ fallback_class(assigns)
       end
     end
   end

--- a/lib/lotus/component.ex
+++ b/lib/lotus/component.ex
@@ -5,6 +5,12 @@ defmodule Lotus.Component do
   defmacro __using__(_) do
     quote do
       use Surface.Component
+      use Lotus.Props.Padding
+      use Lotus.Props.Width
+
+      defp get_classes(assigns) do
+        padding_class(assigns) ++ width_class(assigns)
+      end
     end
   end
 end

--- a/lib/lotus/component.ex
+++ b/lib/lotus/component.ex
@@ -5,11 +5,12 @@ defmodule Lotus.Component do
   defmacro __using__(_) do
     quote do
       use Surface.Component
+      use Lotus.Props.FallbackClass
       use Lotus.Props.Padding
       use Lotus.Props.Width
 
       defp get_classes(assigns) do
-        padding_class(assigns) ++ width_class(assigns)
+        padding_class(assigns) ++ width_class(assigns) ++ fallback_class(assigns)
       end
     end
   end

--- a/lib/lotus/props/child_width.ex
+++ b/lib/lotus/props/child_width.ex
@@ -1,0 +1,21 @@
+defmodule Lotus.Props.ChildWidth do
+  @moduledoc """
+  Child width props. Define the child width of elements for different viewport sizes.
+
+  See more: https://getuikit.com/docs/width
+  """
+  defmacro __using__(_) do
+    quote do
+      alias Lotus.Shared.Width, as: WidthHelper
+
+      @doc """
+      Child width
+      """
+      prop width, :string, values: WidthHelper.width_specs()
+
+      defp child_width_class(assigns) do
+        WidthHelper.assigns_to_chilld_width_classes(assigns)
+      end
+    end
+  end
+end

--- a/lib/lotus/props/fallback_class.ex
+++ b/lib/lotus/props/fallback_class.ex
@@ -1,0 +1,15 @@
+defmodule Lotus.Props.FallbackClass do
+  @moduledoc """
+  Fallback classes, use class-list for mixing classes that are not part of the Lotus API (yet)
+  """
+  defmacro __using__(_) do
+    quote do
+      @doc """
+      Additional classes
+      """
+      prop class, :css_class, default: []
+
+      defp fallback_class(assigns), do: assigns.class
+    end
+  end
+end

--- a/lib/lotus/props/padding.ex
+++ b/lib/lotus/props/padding.ex
@@ -1,0 +1,30 @@
+defmodule Lotus.Props.Padding do
+  @moduledoc """
+  Padding props. Adds padding to any element. See more: https://getuikit.com/docs/padding
+  """
+  defmacro __using__(_) do
+    quote do
+      @padding_values ~w/default small large/
+
+      @doc """
+      Padding size
+      """
+      prop padding, :string, values: @padding_values
+
+      @doc """
+      Remove vertical or horizontal padding only
+      """
+      prop remove_padding, :string, values: ~w/default vertical horizontal top bottom/
+
+      defp padding_class(assigns) do
+        Surface.css_class(
+          "uk-padding": assigns.padding == "default",
+          "uk-padding-#{assigns.padding}": assigns.padding,
+          "uk-padding-remove": assigns.remove_padding == "default",
+          "uk-padding-remove-#{assigns.remove_padding}": assigns.remove_padding
+        )
+        |> List.wrap()
+      end
+    end
+  end
+end

--- a/lib/lotus/props/text.ex
+++ b/lib/lotus/props/text.ex
@@ -1,0 +1,76 @@
+defmodule Lotus.Props.Text do
+  @moduledoc """
+  A collection of utility classes to style text.
+
+  Read more: https://getuikit.com/docs/text
+  """
+  defmacro __using__(_) do
+    quote do
+      @doc """
+      Text style
+      """
+      prop text_lead, :string, values: ~w/lead meta/
+
+      @doc """
+      Font size
+      """
+      prop font_size, :string, values: ~w/small default large/
+
+      @doc """
+      Font weight
+      """
+      prop font_weight, :string, values: ~w/light normal bold lighter bolder/
+
+      @doc """
+      Italic
+      """
+      prop font_italic, :boolean
+
+      @doc """
+      Text Transform
+      """
+      prop text_transform, :string, values: ~w/capitalize uppercase lowercase/
+
+      @doc """
+      No text decoration
+      """
+      prop no_text_decoration, :boolean
+
+      @doc """
+      Text Color
+      """
+      prop text_color, :string, values: ~w/muted emphasis primary secondary success warning danger/
+
+      @doc """
+      Text horizontal alignment
+      """
+      prop text_align, :string, values: ~w/left right center justify/
+
+      @doc """
+      Text vertical alignment
+      """
+      prop text_valign, :string, values: ~w/top middle bottom baseline/
+
+      @doc """
+      Text wrapping
+      """
+      prop text_wrap, :string, values: ~w/truncate break nowarp/
+
+      defp text_class(assigns) do
+        Surface.css_class(
+          "uk-text-#{assigns.text_lead}": assigns.text_lead,
+          "uk-text-#{assigns.font_size}": assigns.font_size,
+          "uk-text-#{assigns.font_weight}": assigns.font_weight,
+          "uk-text-italic": assigns.font_italic,
+          "uk-text-#{assigns.text_transform}": assigns.text_transform,
+          "uk-text-decoration-none": assigns.no_text_decoration,
+          "uk-text-#{assigns.text_color}": assigns.text_color,
+          "uk-text-#{assigns.text_align}": assigns.text_align,
+          "uk-text-#{assigns.text_valign}": assigns.text_valign,
+          "uk-text-#{assigns.text_wrap}": assigns.text_wrap
+        )
+        |> List.wrap()
+      end
+    end
+  end
+end

--- a/lib/lotus/props/text.ex
+++ b/lib/lotus/props/text.ex
@@ -39,7 +39,8 @@ defmodule Lotus.Props.Text do
       @doc """
       Text Color
       """
-      prop text_color, :string, values: ~w/muted emphasis primary secondary success warning danger/
+      prop text_color, :string,
+        values: ~w/muted emphasis primary secondary success warning danger/
 
       @doc """
       Text horizontal alignment

--- a/lib/lotus/props/utility.ex
+++ b/lib/lotus/props/utility.ex
@@ -1,0 +1,49 @@
+defmodule Lotus.Props.Utility do
+  @moduledoc """
+  Various utilities as defined in: https://getuikit.com/docs/utility
+  """
+  defmacro __using__(_) do
+    quote do
+      @doc """
+      Display property
+      """
+      prop display, :string, values: ~w/block inline inline-block/
+
+      @doc """
+      Border Radius
+      """
+      prop border_radius, :string, values: ~w/rounded circle pill/
+
+      @doc """
+      Box Shadow
+      """
+      prop box_shadow, :string, values: ~w/small medium large xlarge/
+
+      @doc """
+      Box shadow bottom
+      """
+      prop box_shadow_bottom, :boolean
+
+      @doc """
+      Hover
+      """
+      prop box_shadow_hover, :string, values: ~w/small medium large xlarge/
+
+      @doc """
+      Disabled
+      """
+      prop disabled, :boolean
+
+      defp utility_class(assigns) do
+        Surface.css_class(
+          "uk-display-#{assigns.display}": assigns.display,
+          "uk-border-#{assigns.border_radius}": assigns.border_radius,
+          "uk-box-shadow-#{assigns.box_shadow}": assigns.box_shadow,
+          "uk-box-shadow-bottom": assigns.box_shadow_bottom,
+          "uk-box-shadow-hover-#{assigns.box_shadow_hover}": assigns.box_shadow_hover
+        )
+        |> List.wrap()
+      end
+    end
+  end
+end

--- a/lib/lotus/props/width.ex
+++ b/lib/lotus/props/width.ex
@@ -1,0 +1,21 @@
+defmodule Lotus.Props.Width do
+  @moduledoc """
+  Width props. Define the width of elements for different viewport sizes.
+
+  See more: https://getuikit.com/docs/width
+  """
+  defmacro __using__(_) do
+    quote do
+      alias Lotus.Shared.Width, as: WidthHelper
+
+      @doc """
+      Width
+      """
+      prop width, :string, values: WidthHelper.width_specs()
+
+      defp width_class(assigns) do
+        WidthHelper.assigns_to_width_classes(assigns)
+      end
+    end
+  end
+end


### PR DESCRIPTION

![20210918_021416](https://user-images.githubusercontent.com/5702155/133878473-fb1a6b4e-508a-4e15-83e6-03c0d2cd81be.jpg)
Added a host of utility classes. Postponed the design plan of adding separate `Block` vs `Inline` utilities since they only have a few in difference. For now, we can make do with the fallback classes.

Decided to have separate components `<Block>` and `<Span>` which will be `<div>` and `<span>` equivalent. So for example, instead of `<Text ... />` we can have `<Block text-decoration=... el="p" />` etc. Will be thinking about that next.